### PR TITLE
Adds docker_pull option to allow using an image without pulling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This will create:
 * `ports` (default: _[]_) - List of `-p` arguments
 * `link` (default: _[]_) - List of `--link` arguments
 * `labels` (default: _[]_) - List of `-l` arguments
+* `docker_pull` (default: _yes_) - whether the docker image should be pulled
 
 #### Systemd service specifics
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ links: []
 enabled: yes
 masked: no
 state: started
+docker_pull: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,6 +11,7 @@
 # use `command` instead of `docker_image` so we don't have to install docker-py
 - name: Pull image {{ image }}
   command: docker pull {{ image }}
+  when: docker_pull
 
 # TODO: Add handler to restart service after new image has been pulled
 - name: Create unit {{ name }}_container.service


### PR DESCRIPTION
In my playbook I build and tag my own image before docker-systemd-service. The image does not exist on the docker hub, so the explicit pull was failing. Now I can just pass ```docker_pull: no``` to skip the pull step and just load the image already downloaded.