### PR TITLE
Prefix role variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Generic role for creating systemd services to manage docker containers.
     name: docker-systemd-service
   vars:
     name: myapp
-    image: myapp:latest
-    args: >
-      --link mysql
-      -v /data/uploads:/data/uploads
-      -p 3000:3000
-    env:
+    container_image: myapp:latest
+    container_links: [ 'mysql' ]
+    container_volumes:
+      - '/data/uploads:/data/uploads'
+    container_ports:
+      - '3000:3000'
+    container_env:
       MYSQL_ROOT_PASSWORD: "{{ mysql_root_pw }}"
 ```
 
@@ -27,20 +28,20 @@ This will create:
 
 ### Role variables
 
-* `name` (**required**) - name of the service
+* `name` (**required**) - name of the container
 
 #### Docker container specifics
 
-* `image` (**required**) - Docker image the service uses
-* `args` - arbitrary list of arguments to the `docker run` command
-* `cmd` - optional command to the container run command (the part after the
+* `container_image` (**required**) - Docker image the service uses
+* `container_args` - arbitrary list of arguments to the `docker run` command
+* `container_cmd` - optional command to the container run command (the part after the
   image name)
-* `env` - key/value pairs of ENV vars that need to be present
-* `volumes` (default: _[]_) - List of `-v` arguments
-* `ports` (default: _[]_) - List of `-p` arguments
-* `link` (default: _[]_) - List of `--link` arguments
-* `labels` (default: _[]_) - List of `-l` arguments
-* `docker_pull` (default: _yes_) - whether the docker image should be pulled
+* `container_env` - key/value pairs of ENV vars that need to be present
+* `container_volumes` (default: _[]_) - List of `-v` arguments
+* `container_ports` (default: _[]_) - List of `-p` arguments
+* `container_link` (default: _[]_) - List of `--link` arguments
+* `container_labels` (default: _[]_) - List of `-l` arguments
+* `container_docker_pull` (default: _yes_) - whether the docker image should be pulled
 
 #### Systemd service specifics
 
@@ -64,6 +65,9 @@ and run `ansible-galaxy install -r requirements.yml`.
 
 * When the unit or env file is changed, systemd gets reloaded but existing
   containers are NOT restarted.
+* Make sure to quote values for `container_ports`, `container_volumes` and so
+  on, especially if they contain colons (`:`). Otherwise YAML will interpret
+  them as hashes/maps and ansible will throw up.
 
 ## About orchestrating Docker containers using systemd.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-volumes: []
-labels: []
-ports: []
-links: []
-enabled: yes
-masked: no
-state: started
-docker_pull: yes
+container_docker_pull: yes
+container_labels: []
+container_links: []
+container_ports: []
+container_volumes: []
+service_enabled: yes
+service_masked: no
+service_state: started

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,12 +6,12 @@
     owner: root
     group: root
     mode: '0600'
-  when: env is defined
+  when: container_env is defined
 
 # use `command` instead of `docker_image` so we don't have to install docker-py
-- name: Pull image {{ image }}
-  command: docker pull {{ image }}
-  when: docker_pull
+- name: Pull image {{ container_image }}
+  command: docker pull {{ container_image }}
+  when: container_docker_pull
 
 # TODO: Add handler to restart service after new image has been pulled
 - name: Create unit {{ name }}_container.service
@@ -26,6 +26,6 @@
   systemd:
     name: '{{ name }}_container.service'
     daemon_reload: true
-    enabled: "{{ enabled }}"
-    masked: "{{ masked }}"
-    state: "{{ state }}"
+    enabled: "{{ container_enabled }}"
+    masked: "{{ container_masked }}"
+    state: "{{ container_state }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,6 @@
   tags: always
 
 - include: install.yml
-  when: state != "absent"
+  when: service_state != "absent"
 - include: uninstall.yml
-  when: state == "absent"
+  when: service_state == "absent"

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,3 @@
-{% for k,v in env.iteritems() %}
+{% for k,v in container_env.iteritems() %}
 {{ k }}={{ v }}
 {% endfor %}

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -8,11 +8,11 @@ PartOf=docker.service
 Requires=docker.service
 
 [Service]
-{% if env is defined %}
+{% if container_env is defined %}
 EnvironmentFile={{ sysconf_dir }}/{{ name }}
 {% endif %}
 ExecStartPre=-/usr/bin/docker rm -f {{ name }}
-ExecStart=/usr/bin/docker run --name {{ name }} --rm {% if env is defined %}--env-file {{ sysconf_dir }}/{{ name }} {% endif %}{{ params('v', volumes) }}{{ params('p', ports) }}{{ params('-link', links) }}{{ params('l', labels) }}{{ args | default('') |trim }} {{ image }} {{ cmd | default('') | trim }}
+ExecStart=/usr/bin/docker run --name {{ name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ name }} {% endif %}{{ params('v', container_volumes) }}{{ params('p', container_ports) }}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
 ExecStop=/usr/bin/docker stop {{ name }}
 
 SyslogIdentifier={{ name }}


### PR DESCRIPTION
The current implementation uses some quite generic variable names, such
as `state`. As role defaults have the lowest priority when it comes to
variable precedence, they are easily overwritten.

This is a breaking change!

Fixes #2