### PR TITLE
Fix container name used for systemd unit file etc.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+container_name: mycontainer
 container_docker_pull: yes
 container_labels: []
 container_links: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-container_name: mycontainer
+container_name: "{{ name }}"
 container_docker_pull: yes
 container_labels: []
 container_links: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
-- name: Create ENV file for {{ name }}_container.service
+- name: Create ENV file for {{ container_name }}_container.service
   template:
     src: env.j2
-    dest: "{{ sysconf_dir }}/{{ name }}"
+    dest: "{{ sysconf_dir }}/{{ container_name }}"
     owner: root
     group: root
     mode: '0600'
@@ -14,17 +14,17 @@
   when: container_docker_pull
 
 # TODO: Add handler to restart service after new image has been pulled
-- name: Create unit {{ name }}_container.service
+- name: Create unit {{ container_name }}_container.service
   template:
     src: unit.j2
-    dest: /etc/systemd/system/{{ name }}_container.service
+    dest: /etc/systemd/system/{{ container_name }}_container.service
     owner: root
     group: root
     mode: '0644'
 
-- name: Enable and start {{ name }}
+- name: Enable and start {{ container_name }}
   systemd:
-    name: '{{ name }}_container.service'
+    name: '{{ container_name }}_container.service'
     daemon_reload: true
     enabled: "{{ service_enabled }}"
     masked: "{{ service_masked }}"

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,18 +1,18 @@
 ---
-- name: Remove ENV file for {{ name }}_container.service
+- name: Remove ENV file for {{ container_name }}_container.service
   file:
-    path: "{{ sysconf_dir }}/{{ name }}"
+    path: "{{ sysconf_dir }}/{{ container_name }}"
     state: absent
 
-- name: Disable and stop {{ name }}
+- name: Disable and stop {{ container_name }}
   systemd:
-    name: '{{ name }}_container.service'
+    name: '{{ container_name }}_container.service'
     enabled: False
     state: stopped
 
-- name: Remove unit {{ name }}_container.service
+- name: Remove unit {{ container_name }}_container.service
   file:
-    path: /etc/systemd/system/{{ name }}_container.service
+    path: /etc/systemd/system/{{ container_name }}_container.service
     state: absent
 
 - name: Reload systemd units

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -9,13 +9,13 @@ Requires=docker.service
 
 [Service]
 {% if container_env is defined %}
-EnvironmentFile={{ sysconf_dir }}/{{ name }}
+EnvironmentFile={{ sysconf_dir }}/{{ container_name }}
 {% endif %}
-ExecStartPre=-/usr/bin/docker rm -f {{ name }}
-ExecStart=/usr/bin/docker run --name {{ name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ name }} {% endif %}{{ params('v', container_volumes) }}{{ params('p', container_ports) }}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
-ExecStop=/usr/bin/docker stop {{ name }}
+ExecStartPre=-/usr/bin/docker rm -f {{ container_name }}
+ExecStart=/usr/bin/docker run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{{ params('p', container_ports) }}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
+ExecStop=/usr/bin/docker stop {{ container_name }}
 
-SyslogIdentifier={{ name }}
+SyslogIdentifier={{ container_name }}
 Restart=always
 
 [Install]


### PR DESCRIPTION
`name` seems to be the name of the role - my systemd unit files were
always called `mhutter.docker-systemd-service_container.service` which
was annoying and didn't scale...

This change requires you to use `container_name` to differentiate
containers.