### PR TITLE
Add handler to restart container when the configuration changed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: "restart container {{ container_name }}"
+  service:
+    name: '{{ container_name }}_container.service'
+    state: restarted
+  when: service_state != "stopped" and enable_and_start.changed == False

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,6 +7,7 @@
     group: root
     mode: '0600'
   when: container_env is defined
+  notify: restart container {{ container_name }}
 
 # use `command` instead of `docker_image` so we don't have to install docker-py
 - name: Pull image {{ container_image }}
@@ -21,6 +22,7 @@
     owner: root
     group: root
     mode: '0644'
+  notify: restart container {{ container_name }}
 
 - name: Enable and start {{ container_name }}
   systemd:
@@ -29,3 +31,4 @@
     enabled: "{{ service_enabled }}"
     masked: "{{ service_masked }}"
     state: "{{ service_state }}"
+  register: enable_and_start

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -17,6 +17,7 @@ ExecStop=/usr/bin/docker stop {{ container_name }}
 
 SyslogIdentifier={{ container_name }}
 Restart=always
+RestartSec=10s
 
 [Install]
 WantedBy=docker.service


### PR DESCRIPTION
This PR add handler + notify to restart container when you change the configuration
of the systemd service or change env vars of a container.

`register: enable_and_start` is here to avoid restart of a container during the first run.
As in case of a started state, the container is first started by the Enable and start service.
Then restarted by the handler which have been notified because the configuration "changed".

Also add `RestartSec=10s` in the template to let 10 sec before systemd try to restart a container.
This avoid to end in systemd start burst limit when a container fail.