### PR TITLE
Fix host network flag not applying

### DIFF
--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -12,7 +12,7 @@ Requires=docker.service
 EnvironmentFile={{ sysconf_dir }}/{{ container_name }}
 {% endif %}
 ExecStartPre=-{{ docker_path }} rm -f {{ container_name }}
-ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network is defined and container_host_network == true %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
+ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network == true %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
 ExecStop=/usr/bin/docker stop {{ container_name }}
 
 SyslogIdentifier={{ container_name }}

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -12,7 +12,7 @@ Requires=docker.service
 EnvironmentFile={{ sysconf_dir }}/{{ container_name }}
 {% endif %}
 ExecStartPre=-{{ docker_path }} rm -f {{ container_name }}
-ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
+ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network is defined and container_host_network == true %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
 ExecStop=/usr/bin/docker stop {{ container_name }}
 
 SyslogIdentifier={{ container_name }}


### PR DESCRIPTION
The comparison wasn't explicit enough to allow for `--network host` to be applied. This addresses that so that if `container_host_network` is defined and `true` the unit will have the appropriate flag.