### PR TITLE
Add optional service_name variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ container_volumes: []
 container_cap_add: []
 container_cap_drop: []
 docker_path: "/usr/bin/docker"
+service_name: "{{ container_name }}_container"
 service_enabled: true
 service_masked: false
 service_state: started

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,6 @@
 ---
-
 - name: "restart container {{ container_name }}"
   service:
-    name: '{{ container_name }}_container.service'
+    name: '{{ service_name }}.service'
     state: restarted
   when: service_state != "stopped" and enable_and_start.changed == False

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,8 +14,8 @@
     name: '{{ container_image }}'
     force: true
   when: container_docker_pull
+  notify: restart container {{ container_name }}
 
-# TODO: Add handler to restart service after new image has been pulled
 - name: Create unit {{ service_name }}.service
   template:
     src: "{{ template_unit_path }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create ENV file for {{ container_name }}_container.service
+- name: Create ENV file for {{ service_name }}.service
   template:
     src: "{{ template_env_path }}"
     dest: "{{ sysconf_dir }}/{{ container_name }}"
@@ -14,12 +14,12 @@
     name: '{{ container_image }}'
     force: true
   when: container_docker_pull
+  notify: restart container {{ container_name }}
 
-# TODO: Add handler to restart service after new image has been pulled
-- name: Create unit {{ container_name }}_container.service
+- name: Create unit {{ service_name }}.service
   template:
     src: "{{ template_unit_path }}"
-    dest: /etc/systemd/system/{{ container_name }}_container.service
+    dest: /etc/systemd/system/{{ service_name }}.service
     owner: root
     group: root
     mode: '0644'
@@ -27,7 +27,7 @@
 
 - name: Enable and start {{ container_name }}
   systemd:
-    name: '{{ container_name }}_container.service'
+    name: '{{ service_name }}.service'
     daemon_reload: true
     enabled: "{{ service_enabled }}"
     masked: "{{ service_masked }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,8 +14,8 @@
     name: '{{ container_image }}'
     force: true
   when: container_docker_pull
-  notify: restart container {{ container_name }}
 
+# TODO: Add handler to restart service after new image has been pulled
 - name: Create unit {{ service_name }}.service
   template:
     src: "{{ template_unit_path }}"

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,18 +1,18 @@
 ---
-- name: Remove ENV file for {{ container_name }}_container.service
+- name: Remove ENV file for {{ service_name }}.service
   file:
     path: "{{ sysconf_dir }}/{{ container_name }}"
     state: absent
 
 - name: Disable and stop {{ container_name }}
   systemd:
-    name: '{{ container_name }}_container.service'
+    name: '{{ service_name }}.service'
     enabled: false
     state: stopped
 
-- name: Remove unit {{ container_name }}_container.service
+- name: Remove unit {{ service_name }}.service
   file:
-    path: /etc/systemd/system/{{ container_name }}_container.service
+    path: /etc/systemd/system/{{ service_name }}.service
     state: absent
 
 - name: Reload systemd units


### PR DESCRIPTION
This PR adds var definition `service_name` allowing for an optional override of the systemd service name independent of the underlying image name.
Default value maintains current behavior unchanged