### PR TITLE
Allow adding/overriding systemd service options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This will create:
 * `masked` (default: _no_) - whether the service should be masked
 * `state` (default: _started_) - state the service should be in - set to
 * `absent` to remove the service.
-* `service_name` (default: `<container_name>)_container`) - name of the systemd service
+* `name` (default: `<container_name>)_container`) - name of the systemd service
 * `systemd_options` (default: {}) - Extra options to include in systemd service file
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This will create:
 * `enabled` (default: _yes_) - whether the service should be enabled
 * `masked` (default: _no_) - whether the service should be masked
 * `state` (default: _started_) - state the service should be in - set to
-* `absent` to remove the service.
+  `absent` to remove the service.
 * `name` (default: `<container_name>)_container`) - name of the systemd service
 * `systemd_options` (default: {}) - Extra options to include in systemd service file
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ This will create:
 * `enabled` (default: _yes_) - whether the service should be enabled
 * `masked` (default: _no_) - whether the service should be masked
 * `state` (default: _started_) - state the service should be in - set to
-  `absent` to remove the service.
+* `absent` to remove the service.
+* `service_name` (default: `<container_name>)_container`) - name of the systemd service
+* `systemd_options` (default: {}) - Extra options to add 
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This will create:
 * `state` (default: _started_) - state the service should be in - set to
 * `absent` to remove the service.
 * `service_name` (default: `<container_name>)_container`) - name of the systemd service
-* `systemd_options` (default: {}) - Extra options to add 
+* `systemd_options` (default: {}) - Extra options to include in systemd service file
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ container_cap_add: []
 container_cap_drop: []
 docker_path: "/usr/bin/docker"
 service_name: "{{ container_name }}_container"
+service_systemd_options: {}
 service_enabled: true
 service_masked: false
 service_state: started

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -8,16 +8,33 @@ PartOf=docker.service
 Requires=docker.service
 
 [Service]
+{% for key, value in service_systemd_options.iteritems() %}
+{{ key }}={{ value }}
+{% endfor %}
 {% if container_env is defined %}
+{% if not 'EnvironmentFile' in service_systemd_options %}
 EnvironmentFile={{ sysconf_dir }}/{{ container_name }}
 {% endif %}
+{% endif %}
+{% if not 'ExecStartPre' in service_systemd_options %}
 ExecStartPre=-{{ docker_path }} rm -f {{ container_name }}
+{% endif %}
+{% if not 'ExecStart' in service_systemd_options %}
 ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network == true %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
+{% endif %}
+{% if not 'ExecStop' in service_systemd_options %}
 ExecStop=/usr/bin/docker stop {{ container_name }}
+{% endif %}
 
+{% if not 'SyslogIdentifier' in service_systemd_options %}
 SyslogIdentifier={{ container_name }}
+{% endif %}
+{% if not 'Restart' in service_systemd_options %}
 Restart=always
+{% endif %}
+{% if not 'RestartSec' in service_systemd_options %}
 RestartSec=10s
+{% endif %}
 
 [Install]
 WantedBy=docker.service


### PR DESCRIPTION
Add option service_systemd_options to allow adding / overriding systemd template options; see https://unix.stackexchange.com/questions/345595/how-to-set-ulimits-on-service-with-systemd/345596#345596 for an example use case
Add missing documentation for service_name parameter introduced with https://github.com/mhutter/ansible-docker-systemd-service/pull/18