### PR TITLE
Allow multiple items with same key in service_systemd_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This will create:
 * `state` (default: _started_) - state the service should be in - set to
   `absent` to remove the service.
 * `name` (default: `<container_name>_container`) - name of the systemd service
-* `systemd_options` (default: {}) - Extra options to include in systemd service file
+* `systemd_options` (default: _[]_) - Extra options to include in systemd service file
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ container_cap_add: []
 container_cap_drop: []
 docker_path: "/usr/bin/docker"
 service_name: "{{ container_name }}_container"
-service_systemd_options: {}
+service_systemd_options: []
 service_enabled: true
 service_masked: false
 service_state: started

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -2,40 +2,41 @@
 {% macro params(name, vals) %}
 {% for v in vals %}-{{ name }} {{ v }} {% endfor %}
 {% endmacro %}
+{% set service_systemd_options_keys = service_systemd_options | selectattr("key") | map(attribute="key") | list %}
 [Unit]
 After=docker.service
 PartOf=docker.service
 Requires=docker.service
 
 [Service]
-{% for key, value in service_systemd_options.iteritems() %}
-{{ key }}={{ value }}
+{% for item in service_systemd_options %}
+{{ item['key'] }}={{ item['value'] }}
 {% endfor %}
 {% if container_env is defined %}
-{% if not 'EnvironmentFile' in service_systemd_options %}
+{% if not 'EnvironmentFile' in service_systemd_options_keys %}
 EnvironmentFile={{ sysconf_dir }}/{{ container_name }}
 {% endif %}
 {% endif %}
-{% if not 'ExecStartPre' in service_systemd_options %}
+{% if not 'ExecStartPre' in service_systemd_options_keys %}
 ExecStartPre=-{{ docker_path }} rm -f {{ container_name }}
 {% endif %}
-{% if not 'ExecStart' in service_systemd_options %}
+{% if not 'ExecStart' in service_systemd_options_keys %}
 ExecStart={{ docker_path }} run --name {{ container_name }} --rm {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}{{ params('v', container_volumes) }}{% if container_host_network == true %} --network host {% else %}{{ params('p', container_ports) }}{% endif %}{{ params('-link', container_links) }}{{ params('l', container_labels) }}{{ params('-cap-add', container_cap_add) }}{{ params('-cap-drop', container_cap_drop) }}{{ container_args | default('') |trim }} {{ container_image }} {{ container_cmd | default('') | trim }}
 {% endif %}
-{% if not 'ExecStop' in service_systemd_options %}
+{% if not 'ExecStop' in service_systemd_options_keys %}
 ExecStop=/usr/bin/docker stop {{ container_name }}
 {% endif %}
 {% if container_start_post is defined %}
 ExecStartPost=-{{ container_start_post }}
 {% endif %}
 
-{% if not 'SyslogIdentifier' in service_systemd_options %}
+{% if not 'SyslogIdentifier' in service_systemd_options_keys %}
 SyslogIdentifier={{ container_name }}
 {% endif %}
-{% if not 'Restart' in service_systemd_options %}
+{% if not 'Restart' in service_systemd_options_keys %}
 Restart=always
 {% endif %}
-{% if not 'RestartSec' in service_systemd_options %}
+{% if not 'RestartSec' in service_systemd_options_keys %}
 RestartSec=10s
 {% endif %}
 


### PR DESCRIPTION
This allows adding multiple `EnvironmentFile`s or similar things.