### PR TITLE
ensure environment variables stay ordered

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,3 @@
-{% for k,v in container_env.items() %}
+{% for k,v in container_env|dictsort %}
 {{ k }}={{ v }}
 {% endfor %}


### PR DESCRIPTION
This ensures that order in env file stays the same across different ansible versions (e.g. 2.8 and 2.9).