### PR TITLE
Allow to disable service restart on changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This will create:
 * `masked` (default: _no_) - whether the service should be masked
 * `state` (default: _started_) - state the service should be in - set to
   `absent` to remove the service.
+* `restart` (default: _yes_) - whether the service should be restarted on changes
 * `name` (default: `<container_name>_container`) - name of the systemd service
 * `systemd_options` (default: _[]_) - Extra options to include in systemd service file
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,6 @@ service_systemd_options: []
 service_enabled: true
 service_masked: false
 service_state: started
+service_restart: true
 template_env_path: "env.j2"
 template_unit_path: "unit.j2"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,4 @@
   service:
     name: '{{ service_name }}.service'
     state: restarted
-  when: service_state != "stopped" and enable_and_start.changed == False
+  when: service_restart and service_state != "stopped" and enable_and_start.changed == False


### PR DESCRIPTION
This allows having a separate deployment process for orderly changes to applications.