### PR TITLE
Add support for docker's '--network' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This will create:
 * `container_docker_pull` (default: _yes_) - whether the docker image should be pulled
 * `container_cap_add` (default _[]_) - List of capabilities to add
 * `container_cap_drop` (default _{}_) - List of capabilities to drop
+* `container_network` (default _""_) - [Network settings](https://docs.docker.com/engine/reference/run/#network-settings)
 * `container_devices` (default _[]_) - List of devices to add
 * `container_privileged` (default _false_) - Whether the container should be privileged
 * `container_start_post` - Optional command to be run by systemd after the container has started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ container_name: "{{ name }}"
 container_docker_pull: true
 container_labels: []
 container_host_network: false
+container_network: ""
 container_links: []
 container_ports: []
 container_volumes: []

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -27,6 +27,7 @@ ExecStart={{ docker_path }} run \
   {% if container_env is defined %}--env-file {{ sysconf_dir }}/{{ container_name }} {% endif %}\
   {{ params('--volume', container_volumes) }}\
   {% if container_host_network == true %}--network host {% else %}{{ params('--publish', container_ports) }}{% endif %}\
+  {% if container_network %}--network {{ container_network }}{% endif %} \
   {{ params('--link', container_links) }}\
   {{ params('--label', container_labels) }}\
   {{ params('--cap-add', container_cap_add) }}\


### PR DESCRIPTION
Adding support for [docker network settings](https://docs.docker.com/engine/reference/run/#network-settings)

Example configuration:

```yaml
- name: Start MySQL database
  include_role:
    name: docker-systemd-service
  vars:
    container_name: "name"
    container_image: "mysql:8.0.23"

    container_volumes:
      - '{{ mysql_container_volume_host_path }}:/var/lib/mysql:rw'
    
    # Export database port on localhost
    container_ports:
      - '127.0.0.1:3306:3306'

    container_network: "my-network-name"
 
    container_env:
      MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
      MYSQL_DATABASE: "{{ mysql_database }}"
```