### PR TITLE
container_cmd: Switch from string to list to support long cmds in a more readable way

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ This will create:
 
 * `container_image` (**required**) - Docker image the service uses
 * `container_args` - arbitrary list of arguments to the `docker run` command as a string
-* `container_cmd` - optional command to the container run command (the part after the
-  image name)
+* `container_cmd` (default: _[]_) - optional list of commands to the container run command (the part after the image name)
 * `container_env` - key/value pairs of ENV vars that need to be present
 * `container_volumes` (default: _[]_) - List of `-v` arguments
 * `container_host_network` (default: _false_) - Whether the host network should be used

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 container_name: "{{ name }}"
 container_docker_pull: true
 container_labels: []
+container_cmd: []
 container_host_network: false
 container_links: []
 container_ports: []

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -34,7 +34,7 @@ ExecStart={{ docker_path }} run \
   {{ params('--device', container_devices) }}\
   {% if container_privileged == true %}--privileged{% endif %}\
   {{ container_args | trim }} \
-  {{ container_image }} {{ container_cmd | default('') | trim }}
+  {{ container_image }} {{ container_cmd | join(' ') }}
 {% endif %}
 {% if not 'ExecStop' in service_systemd_options_keys %}
 ExecStop=/usr/bin/docker stop {{ container_name }}

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -34,7 +34,7 @@ ExecStart={{ docker_path }} run \
   {{ params('--device', container_devices) }}\
   {% if container_privileged == true %}--privileged{% endif %}\
   {{ container_args | trim }} \
-  {{ container_image }} {{ container_cmd | join(' ') }}
+  {{ container_image }} {% if container_cmd is string %}{{ container_cmd | default('') | trim }}{% else %}{{ container_cmd | join(' ') }}{% endif %}
 {% endif %}
 {% if not 'ExecStop' in service_systemd_options_keys %}
 ExecStop=/usr/bin/docker stop {{ container_name }}

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -34,7 +34,7 @@ ExecStart={{ docker_path }} run \
   {{ params('--device', container_devices) }}\
   {% if container_privileged == true %}--privileged{% endif %}\
   {{ container_args | trim }} \
-  {{ container_image }} {% if container_cmd is string %}{{ container_cmd | default('') | trim }}{% else %}{{ container_cmd | join(' ') }}{% endif %}
+  {{ container_image }} {% if container_cmd is string %}{{ container_cmd | trim }}{% else %}{{ container_cmd | join(' ') | trim }}{% endif %}
 {% endif %}
 {% if not 'ExecStop' in service_systemd_options_keys %}
 ExecStop=/usr/bin/docker stop {{ container_name }}


### PR DESCRIPTION
This PR changes `container_cmd` from a simple string to a list.

The main purpose is to make long container cmds more readable for humans.

Attention: This is a breaking change!

An example might be the configuration of a traefik container:
```yaml
- name: Start traefik application proxy
  include_role:
    name: docker-systemd-service
  vars:
    container_name: "loadbalancer"
    container_image: "traefik:v2.5.6"

    container_cmd:
      - "--entrypoints.websecure.address=:443"
      - "--api"
      - "--providers.docker=true"
      - "--providers.docker.exposedByDefault=false"
      - "--certificatesresolvers.letsencrypt.acme.dnschallenge=true"
      - "--certificatesresolvers.letsencrypt.acme.dnschallenge.provider=digitalocean"
      # - "--certificatesResolvers.letsencrypt.acme.tlsChallenge=true"
      - "--certificatesresolvers.letsencrypt.acme.email=e@mail.com"
      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
      # Lets Encrypt staging server
      # - "--certificatesResolvers.letsencrypt.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory",
      #- "--log.level=DEBUG"

[...]
```

On top of this: this change enables comments for parts of the commands.