### PR TITLE
Make `docker_image.force_source` configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This will create:
 * `container_links` (default: _[]_) - List of `--link` arguments
 * `container_labels` (default: _[]_) - List of `-l` arguments
 * `container_docker_pull` (default: _yes_) - whether the docker image should be pulled
+* `container_docker_pull_force_source` (default: _yes_) - whether the docker image pull should be executed at every time (see [`docker_image.force_source`](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_image_module.html#parameter-force_source))
 * `container_cap_add` (default _[]_) - List of capabilities to add
 * `container_cap_drop` (default _{}_) - List of capabilities to drop
 * `container_network` (default _""_) - [Network settings](https://docs.docker.com/engine/reference/run/#network-settings)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 container_name: "{{ name }}"
 container_docker_pull: true
+container_docker_pull_force_source: true
 container_labels: []
 container_cmd: []
 container_host_network: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
 - name: Pull image {{ container_image }}
   docker_image:
     name: '{{ container_image }}'
-    force_source: true
+    force_source: '{{ container_docker_pull_force_source | bool }}'
     source: pull
   when: container_docker_pull
   notify: restart container {{ container_name }}


### PR DESCRIPTION
Each ansible execution, this task is marked as changed.
In my usecase, I don't want to have `docker_image.force_source` enforced.

This PR makes this setting configurable.
The change is backwards compatible.