### PR TITLE
feat: Add support for customization of the [Unit] systemd service section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ This will create:
 
 #### Systemd service specifics
 
+**Note**: These options are all prefixed by `service_`.
+
 * `enabled` (default: _yes_) - whether the service should be enabled
 * `masked` (default: _no_) - whether the service should be masked
 * `state` (default: _started_) - state the service should be in - set to
@@ -64,6 +66,7 @@ This will create:
 * `restart` (default: _yes_) - whether the service should be restarted on changes
 * `name` (default: `<container_name>_container`) - name of the systemd service
 * `systemd_options` (default: _[]_) - Extra options to include in systemd service file
+* `systemd_unit_options`: (default `{"After": "docker.service", "PartOf": "docker.service", "Requires": "docker.service"}`), key/value defining the content of the `[Unit]` service section.
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ container_args: ""
 docker_path: "/usr/bin/docker"
 service_name: "{{ container_name }}_container"
 service_systemd_options: []
+service_systemd_unit_options:
+  After: docker.service
+  PartOf: docker.service
+  Requires: docker.service
 service_enabled: true
 service_masked: false
 service_state: started

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -4,9 +4,9 @@
 {% endmacro %}
 {% set service_systemd_options_keys = service_systemd_options | selectattr("key") | map(attribute="key") | list %}
 [Unit]
-After=docker.service
-PartOf=docker.service
-Requires=docker.service
+{% for key, value in service_systemd_unit_options | dictsort %}
+{{ key }}={{ value }}
+{% endfor %}
 
 [Service]
 {% for item in service_systemd_options %}


### PR DESCRIPTION
By providing custom key/values in the `service_systemd_unit_options`
ansible variable, users are now able to customize the `[Unit]` service
section, to, e.g. define a custom dependency chain, etc.

**Note**: we use the `| dictstort` jinja filter when iterating over the
key/values to make sure the generated file stays stable over time, as we
have no guarantee over the python version ran by users, meaning we can't
expect key/value order to be stable when iterating over a dict.

By chance
```
After=docker.service
PartOf=docker.service
Requires=docker.service
```
is already pre-sorted, meaning that change should be invisible to existing deployments.

Fixes https://github.com/mhutter/ansible-docker-systemd-service/issues/46