### PR TITLE
Add support for docker run `--user`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This will create:
 * `container_cap_add` (default _[]_) - List of capabilities to add
 * `container_cap_drop` (default _{}_) - List of capabilities to drop
 * `container_network` (default _""_) - [Network settings](https://docs.docker.com/engine/reference/run/#network-settings)
+* `container_user` (default _""_) - [User settings](https://docs.docker.com/engine/reference/run/#user)
 * `container_devices` (default _[]_) - List of devices to add
 * `container_privileged` (default _false_) - Whether the container should be privileged
 * `container_start_post` - Optional command to be run by systemd after the container has started

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ container_labels: []
 container_cmd: []
 container_host_network: false
 container_network: ""
+container_user: ""
 container_links: []
 container_ports: []
 container_volumes: []

--- a/templates/unit.j2
+++ b/templates/unit.j2
@@ -28,6 +28,7 @@ ExecStart={{ docker_path }} run \
   {{ params('--volume', container_volumes) }}\
   {% if container_host_network == true %}--network host {% else %}{{ params('--publish', container_ports) }}{% endif %}\
   {% if container_network %}--network {{ container_network }}{% endif %} \
+  {% if container_user %}--user {{ container_user }}{% endif %} \
   {{ params('--link', container_links) }}\
   {{ params('--label', container_labels) }}\
   {{ params('--cap-add', container_cap_add) }}\


### PR DESCRIPTION
This PR enables the `--user` setting to be passed to docker.

See https://docs.docker.com/engine/reference/run/#user

## Checklist

- [X] Keep pull requests small so they can be easily reviewed.
- [X] Update the documentation.
- [ ] Link this PR to related issues.