### PR TITLE
Fix #55: [DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- include: install.yml
+- include_tasks: install.yml
   when: service_state != "absent"
-- include: uninstall.yml
+- include_tasks: uninstall.yml
   when: service_state == "absent"


### PR DESCRIPTION
Fix #55

## Ansible docs:
* https://docs.ansible.com/ansible-core/2.12/user_guide/playbooks_reuse.html#re-using-files-and-roles
* [ansible.builtin.include_tasks module – Dynamically include a task list](https://docs.ansible.com/ansible-core/2.12/collections/ansible/builtin/include_tasks_module.html#ansible-builtin-include-tasks-module-dynamically-include-a-task-list)

## Checklist

- [X] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Link this PR to related issues.