### PR TITLE
Fixed error when using external vars for defining container_name.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "restart container {{ container_name }}"
+- name: "restart container"
   service:
     name: '{{ service_name }}.service'
     state: restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
     group: root
     mode: '0600'
   when: container_env is defined
-  notify: restart container {{ container_name }}
+  notify: restart container
 
 - name: Pull image {{ container_image }}
   docker_image:
@@ -15,7 +15,7 @@
     force_source: '{{ container_docker_pull_force_source | bool }}'
     source: pull
   when: container_docker_pull
-  notify: restart container {{ container_name }}
+  notify: restart container
 
 - name: Create unit {{ service_name }}.service
   template:
@@ -24,7 +24,7 @@
     owner: root
     group: root
     mode: '0644'
-  notify: restart container {{ container_name }}
+  notify: restart container
 
 - name: Enable and start {{ container_name }}
   systemd:


### PR DESCRIPTION
## Checklist

- [X] Keep pull requests small so they can be easily reviewed.
- [X] Link this PR to related issues.
---
Changes:

- Removed dynamic naming of handlers.
- Allow defining 'container_name' variable using a group_var/host_var.
- No need to define 'container_name' in a static way when including this role.

Since using the "service_name" variable (which by default already contains the "container_name" variable) to uniquely identify each service, no need to name the handlers too.

See: https://github.com/ansible/ansible/issues/63822

---
Error scenario:
`playbooks/site.yaml`
```yaml
- hosts: all
  become: true
  roles:
    - role1
```
`group_vars/all.yaml`
```yaml
container_name: 'my_container_test'
container_image: 'my_image_test:latest'
```
`roles1/tasks/main.yaml`
```yaml
- name: Dummy task
  debug:
     msg: "Hello world!"
- name: Including the role.
  include_role:
    name: mhutter.docker-systemd-service
```
Output:
```TASK [mhutter.docker-systemd-service : Create unit my_container_test_container.service] **************************************************************************************************************************
[WARNING]: Handler 'restart container {{ container_name }}' is unusable because it has no listen topics and the name could not be templated (host-specific variables are not supported in handler names). The
error: {{ name }}: 'name' is undefined. 'name' is undefined. {{ name }}: 'name' is undefined. 'name' is undefined
ERROR! The requested handler 'restart container my_container_test' was not found in either the main handlers list nor in the listening handlers list
```
