### PR TITLE
uninstall: first stop the service, then remove env-file

### DIFF
--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,14 +1,14 @@
 ---
-- name: Remove ENV file for {{ service_name }}.service
-  file:
-    path: "{{ sysconf_dir }}/{{ container_name }}"
-    state: absent
-
 - name: Disable and stop {{ container_name }}
   systemd:
     name: '{{ service_name }}.service'
     enabled: false
     state: stopped
+
+- name: Remove ENV file for {{ service_name }}.service
+  file:
+    path: "{{ sysconf_dir }}/{{ container_name }}"
+    state: absent
 
 - name: Remove unit {{ service_name }}.service
   file:


### PR DESCRIPTION
At the time when the service is attempted to be stopped, the systemd.service file still holds a reference to an env file that no longer exists. As a result, the service itself may not be able to be stopped.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
